### PR TITLE
Update star.py

### DIFF
--- a/star.py
+++ b/star.py
@@ -1,24 +1,30 @@
-#%%
 from matplotlib import pyplot as plt
-from skimage import data
-from skimage.feature import blob_dog, blob_log, blob_doh
+from skimage.feature import blob_log
 from math import sqrt
-from skimage.color import rgb2gray
 from matplotlib import cm
 import glob
+from skimage.color import rgb2gray
 from skimage.io import imread
-example_file = glob.glob(r"star.jpg")[0]
-im = imread(example_file, as_grey=True)
-plt.imshow(im, cmap=cm.gray)
+
+example_file = glob.glob("star.jpg")[0]
+im = imread(example_file)
+im_gray = rgb2gray(im)
+
+plt.imshow(im_gray, cmap=cm.gray)
 plt.show()
-blobs_log = blob_log(im, max_sigma=100, num_sigma=5, threshold=.1)
-# Compute radii in the 3rd column.
-blobs_log[:, 5] = blobs_log[:, 2] * sqrt(2)
+
+blobs_log = blob_log(im_gray, max_sigma=100, num_sigma=5, threshold=.1)
+blobs_log[:, 2] = blobs_log[:, 2] * sqrt(2)
+
 numrows = len(blobs_log)
-print("Number of stars counted : " ,numrows)
+print("Number of stars counted:", numrows)
+
 fig, ax = plt.subplots(1, 1)
-plt.imshow(im, cmap=cm.gray)
+plt.imshow(im_gray, cmap=cm.gray)
+
 for blob in blobs_log:
     y, x, r = blob
     c = plt.Circle((x, y), r+5, color='lime', linewidth=2, fill=False)
     ax.add_patch(c)
+
+plt.show()


### PR DESCRIPTION
It seems like you're encountering an error related to the 'as_grey' argument in the imread function. This is because the 'as_grey' argument is not available in more recent versions of scikit-image (v0.18.3 and later). Instead, you can achieve grayscale conversion using other methods.


This code should work without the 'as_grey' argument, as it converts the loaded image to grayscale using rgb2gray from the scikit-image library.